### PR TITLE
Implement SelectText

### DIFF
--- a/TypeScriptSyntaxVisualizer/MyControl.xaml.cs
+++ b/TypeScriptSyntaxVisualizer/MyControl.xaml.cs
@@ -12,7 +12,8 @@ namespace CodeConnect.TypeScriptSyntaxVisualizer
         private readonly System.Windows.Forms.PropertyGrid _propertyGrid;
 
         public bool IsWindowVisible { get; set; }
-        DTE dte = Package.GetGlobalService(typeof(DTE)) as DTE;
+        public bool CaretPosChangeBecauseOfTextSlection { get; set; }
+        private DTE dte = Package.GetGlobalService(typeof(DTE)) as DTE;
 
         public MyControl()
         {
@@ -116,8 +117,11 @@ namespace CodeConnect.TypeScriptSyntaxVisualizer
                 var node = (SyntaxNodeOrToken)item.DataContext;
                 var document = dte.ActiveDocument;
                 var selected = (TextSelection)document.Selection;
+                CaretPosChangeBecauseOfTextSlection = true;
                 selected.StartOfDocument(false);
+                CaretPosChangeBecauseOfTextSlection = true;
                 selected.MoveToAbsoluteOffset(node.StartPosition + 1, false);
+                CaretPosChangeBecauseOfTextSlection = true;
                 selected.MoveToAbsoluteOffset(node.End + 1, true);
             }
             catch (Exception e)

--- a/TypeScriptSyntaxVisualizer/MyControl.xaml.cs
+++ b/TypeScriptSyntaxVisualizer/MyControl.xaml.cs
@@ -12,7 +12,7 @@ namespace CodeConnect.TypeScriptSyntaxVisualizer
         private readonly System.Windows.Forms.PropertyGrid _propertyGrid;
 
         public bool IsWindowVisible { get; set; }
-        public bool CaretPosChangeBecauseOfTextSlection { get; set; }
+        public bool IgnoreNextCaretPositionChange { get; set; }
         private DTE dte = Package.GetGlobalService(typeof(DTE)) as DTE;
 
         public MyControl()
@@ -117,11 +117,11 @@ namespace CodeConnect.TypeScriptSyntaxVisualizer
                 var node = (SyntaxNodeOrToken)item.DataContext;
                 var document = dte.ActiveDocument;
                 var selected = (TextSelection)document.Selection;
-                CaretPosChangeBecauseOfTextSlection = true;
+                IgnoreNextCaretPositionChange = true;
                 selected.StartOfDocument(false);
-                CaretPosChangeBecauseOfTextSlection = true;
+                IgnoreNextCaretPositionChange = true;
                 selected.MoveToAbsoluteOffset(node.StartPosition + 1, false);
-                CaretPosChangeBecauseOfTextSlection = true;
+                IgnoreNextCaretPositionChange = true;
                 selected.MoveToAbsoluteOffset(node.End + 1, true);
             }
             catch (Exception e)

--- a/TypeScriptSyntaxVisualizer/MyControl.xaml.cs
+++ b/TypeScriptSyntaxVisualizer/MyControl.xaml.cs
@@ -1,4 +1,7 @@
-﻿using System.Windows.Controls;
+﻿using EnvDTE;
+using Microsoft.VisualStudio.Shell;
+using System;
+using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
 
@@ -9,6 +12,7 @@ namespace CodeConnect.TypeScriptSyntaxVisualizer
         private readonly System.Windows.Forms.PropertyGrid _propertyGrid;
 
         public bool IsWindowVisible { get; set; }
+        DTE dte = Package.GetGlobalService(typeof(DTE)) as DTE;
 
         public MyControl()
         {
@@ -107,8 +111,18 @@ namespace CodeConnect.TypeScriptSyntaxVisualizer
 
         private void selectText(TreeViewItem item)
         {
-            var node = (SyntaxNodeOrToken)item.DataContext;
-            //TODO
+            try {
+                var node = (SyntaxNodeOrToken)item.DataContext;
+                var document = dte.ActiveDocument;
+                var selected = (TextSelection)document.Selection;
+                selected.StartOfDocument(false);
+                selected.MoveToAbsoluteOffset(node.StartPosition + 1, false);
+                selected.MoveToAbsoluteOffset(node.End + 1, true);
+            }
+            catch (Exception e)
+            {
+                System.Diagnostics.Debug.WriteLine(e.ToString());
+            }
         }
 
         private void treeContainer_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)

--- a/TypeScriptSyntaxVisualizer/MyControl.xaml.cs
+++ b/TypeScriptSyntaxVisualizer/MyControl.xaml.cs
@@ -111,7 +111,8 @@ namespace CodeConnect.TypeScriptSyntaxVisualizer
 
         private void selectText(TreeViewItem item)
         {
-            try {
+            try
+            {
                 var node = (SyntaxNodeOrToken)item.DataContext;
                 var document = dte.ActiveDocument;
                 var selected = (TextSelection)document.Selection;

--- a/TypeScriptSyntaxVisualizer/TextViewCreationListener.cs
+++ b/TypeScriptSyntaxVisualizer/TextViewCreationListener.cs
@@ -20,9 +20,9 @@ namespace CodeConnect.TypeScriptSyntaxVisualizer
                 //Don't waste time computing anything if we can't show it.
                 if (!MyToolWindow.MyControl.IsWindowVisible)
                     return;
-                if (MyToolWindow.MyControl.CaretPosChangeBecauseOfTextSlection)
+                if (MyToolWindow.MyControl.IgnoreNextCaretPositionChange)
                 {
-                    MyToolWindow.MyControl.CaretPosChangeBecauseOfTextSlection = false;
+                    MyToolWindow.MyControl.IgnoreNextCaretPositionChange = false;
                     return;
                 }
 

--- a/TypeScriptSyntaxVisualizer/TextViewCreationListener.cs
+++ b/TypeScriptSyntaxVisualizer/TextViewCreationListener.cs
@@ -20,6 +20,11 @@ namespace CodeConnect.TypeScriptSyntaxVisualizer
                 //Don't waste time computing anything if we can't show it.
                 if (!MyToolWindow.MyControl.IsWindowVisible)
                     return;
+                if (MyToolWindow.MyControl.CaretPosChangeBecauseOfTextSlection)
+                {
+                    MyToolWindow.MyControl.CaretPosChangeBecauseOfTextSlection = false;
+                    return;
+                }
 
                 var caret = (ITextCaret)sender;
                 int position = args.NewPosition.BufferPosition.Position;

--- a/TypeScriptSyntaxVisualizer/TextViewCreationListener.cs
+++ b/TypeScriptSyntaxVisualizer/TextViewCreationListener.cs
@@ -26,11 +26,22 @@ namespace CodeConnect.TypeScriptSyntaxVisualizer
 
                 //We roll the dice on an OOM exception... :(
                 string rawText = caret.ContainingTextViewLine.Snapshot.GetText();
+                string textbeforecaret = rawText.Substring(0, position);
+
+                int linenum = 0;
+                foreach (char c in textbeforecaret)
+                {
+                    if (c == '\r')
+                    {
+                        linenum += 1;
+                    }
+                }
+                rawText = rawText.Replace("\r\n", "\n");
 
                 using (TypeScriptProcessor tsProcessor = new TypeScriptProcessor())
                 {
                     var root = tsProcessor.ParseFileAndGetSyntaxRoot(rawText);
-                    MyToolWindow.MyControl.UpdateWithSyntaxRoot(root, position);
+                    MyToolWindow.MyControl.UpdateWithSyntaxRoot(root, position - linenum);
                     System.Diagnostics.Debug.WriteLine(root.Kind);
                 }
             }

--- a/TypeScriptSyntaxVisualizer/TextViewCreationListener.cs
+++ b/TypeScriptSyntaxVisualizer/TextViewCreationListener.cs
@@ -26,22 +26,15 @@ namespace CodeConnect.TypeScriptSyntaxVisualizer
 
                 //We roll the dice on an OOM exception... :(
                 string rawText = caret.ContainingTextViewLine.Snapshot.GetText();
-                string textbeforecaret = rawText.Substring(0, position);
+                string textBeforeCaret = rawText.Substring(0, position);
 
-                int linenum = 0;
-                foreach (char c in textbeforecaret)
-                {
-                    if (c == '\r')
-                    {
-                        linenum += 1;
-                    }
-                }
+                int lineNumber = getLineNumberAboveCaret(textBeforeCaret, position);
                 rawText = rawText.Replace("\r\n", "\n");
 
                 using (TypeScriptProcessor tsProcessor = new TypeScriptProcessor())
                 {
                     var root = tsProcessor.ParseFileAndGetSyntaxRoot(rawText);
-                    MyToolWindow.MyControl.UpdateWithSyntaxRoot(root, position - linenum);
+                    MyToolWindow.MyControl.UpdateWithSyntaxRoot(root, position - lineNumber);
                     System.Diagnostics.Debug.WriteLine(root.Kind);
                 }
             }
@@ -60,6 +53,19 @@ namespace CodeConnect.TypeScriptSyntaxVisualizer
         public void SubjectBuffersDisconnected(IWpfTextView textView, ConnectionReason reason, Collection<ITextBuffer> subjectBuffers)
         {
             textView.Caret.PositionChanged -= Caret_PositionChanged;
+        }
+
+        private int getLineNumberAboveCaret(string text, int pos)
+        {
+            int lineNumber = 0;
+            foreach (char c in text)
+            {
+                if (c == '\n')
+                {
+                    lineNumber += 1;
+                }
+            }
+            return lineNumber;
         }
     }
 }


### PR DESCRIPTION
This PR allows corresponding text in VS editor to be selected when user clicks on an Item in the tree view of SyntaxVisualizer.
